### PR TITLE
Sort notes by last updated/modified.

### DIFF
--- a/sublime_evernote.py
+++ b/sublime_evernote.py
@@ -392,11 +392,10 @@ class OpenEvernoteNoteCommand(EvernoteDoWindow):
                 return
             nid = notebooks[notebook].guid
             notes = noteStore.findNotesMetadata(
-                self.token(), NoteStore.NoteFilter(notebookGuid=nid),
+                self.token(), NoteStore.NoteFilter(notebookGuid=nid, order=Types.NoteSortOrder.UPDATED),
                 0,
                 100,
                 NoteStore.NotesMetadataResultSpec(includeTitle=True)).notes
-            notes.reverse()
 
             def on_note(i):
                 if i < 0:


### PR DESCRIPTION
When using 'Open Evernote note', It shows only oldest notes from a notebook that contains more than 100 notes.

Change the sort method to retreive newest notes.
