### PR TITLE
Show stack name on list

### DIFF
--- a/sublime_evernote.py
+++ b/sublime_evernote.py
@@ -576,7 +576,8 @@ class OpenEvernoteNoteCommand(EvernoteDoWindow):
         if from_notebook or with_tags:
             notes_panel(self.find_notes(search_args, max_notes), not from_notebook)
         else:
-            self.window.show_quick_panel([notebook.name for notebook in notebooks], on_notebook)
+            nbnames = [nb.stack + ' - ' + nb.name if nb.stack else nb.name for nb in notebooks]
+            self.window.show_quick_panel(nbnames, on_notebook)
 
     def find_notes(self, search_args, max_notes=None):
         return self.get_note_store().findNotesMetadata(


### PR DESCRIPTION
Amazing plugin I have been using it for a couple of days and I love it. Thanks :)

Since I use stacks to group some of my notebooks i made a little change to include the name of the stack on the selection pane. I also tried to sort the notebook by name but the some notebooks opened the wrong notebook, maybe you can help me with that i think it could be a nice setting.

Thanks!
