### PR TITLE
Async operations

### DIFF
--- a/sublime_evernote.py
+++ b/sublime_evernote.py
@@ -543,6 +543,9 @@ class SendToEvernoteCommand(EvernoteDoText):
                 on_cancel()
 
         def __send_note(notebookGuid):
+            sublime.set_timeout_async(lambda: __send_note_async(notebookGuid), 0)
+
+        def __send_note_async(notebookGuid):
             note.notebookGuid = notebookGuid
 
             LOG(note.title)
@@ -600,7 +603,7 @@ class SaveEvernoteNoteCommand(EvernoteDoText):
                 if sublime.ok_cancel_dialog('Evernote complained:\n\n%s\n\nRetry?' % explain_error(e)):
                     self.connect(self.__update_note)
 
-        __update_note()
+        sublime.set_timeout_async(__update_note, 0)
 
     def is_enabled(self):
         if self.view.settings().get("$evernote_guid", False):
@@ -698,6 +701,9 @@ class OpenEvernoteNoteCommand(EvernoteDoWindow):
             NoteStore.NotesMetadataResultSpec(includeTitle=True, includeNotebookGuid=True)).notes
 
     def open_note(self, guid, convert=True, **unk_args):
+        sublime.set_timeout_async(lambda: self.do_open_note(guid, convert, **unk_args),0)
+
+    def do_open_note(self, guid, convert=True, **unk_args):
         try:
             noteStore = self.get_note_store()
             note = noteStore.getNote(self.token(), guid, True, False, False, False)

--- a/sublime_evernote.py
+++ b/sublime_evernote.py
@@ -203,7 +203,7 @@ def async_do(f, progress_msg="Evernote operation", done_msg=None):
         try:
             f()
         except:
-            raise
+            pass
         finally:
             s['done'] = True
 


### PR DESCRIPTION
The idea is to use `sublime.set_timeout_async` to execute slow operations on a parallel thread.
This enables:

 1. more reactive UI (does not block when exchanging a lot of data with server)
 2. better visual feedback with progress indicator in status

The downside is that, being the Sublime threading architecture not well documented/specified, it requires a bit of guesswork to see what could and could not lead to races/deadlocks/None exceptions etc.

I am opening the PR hoping somebody can help me test it before release!