### PR TITLE
Add content wrapper for all markdown

### DIFF
--- a/Evernote.sublime-settings
+++ b/Evernote.sublime-settings
@@ -1,6 +1,7 @@
 {
     // inline_css is documented at https://github.com/bordaigorl/sublime-evernote/wiki/Styling
     "inline_css": {
+        "body_wrapper": "line-height: 1.5; color: #2c3f51; font-family: Helvetica Neue, Arial, Hiragino Sans GB, STHeiti, Microsoft YaHei, WenQuanYi Micro Hei, SimSun, Song, sans-serif;",
         "pre": "color: #000000; font-family: monospace,monospace; font-size: 0.9em; white-space: pre-wrap; word-wrap: break-word; border: 1px solid #cccccc; border-radius: 3px; overflow: auto; padding: 6px 10px; margin-bottom: 10px;",
         "code": "color: black; font-family: monospace,monospace; font-size: 0.9em;",
         "inline-code": "color: #000000; font-family: monospace,monospace; padding: 0.1em 0.2em; margin: 0.1em; font-size: 85%; background-color: #F5F5F5; border-radius: 3px; border: 1px solid #cccccc;",

--- a/sublime_evernote.py
+++ b/sublime_evernote.py
@@ -437,6 +437,14 @@ class EvernoteDo():
         if isinstance(contents, sublime.View):
             contents = contents.substr(sublime.Region(0, contents.size()))
         body = markdown2.markdown(contents, extras=EvernoteDo.MD_EXTRAS)
+
+        body_wrapper = '<div style="%s">\n%s\n</div>'
+        wrapper_style = ''
+        if 'inline-css' in EvernoteDo.MD_EXTRAS:
+            if 'body_wrapper' in EvernoteDo.MD_EXTRAS['inline-css']:
+                wrapper_style = EvernoteDo.MD_EXTRAS['inline-css']['body_wrapper']
+        body_with_wrapper = body_wrapper % (wrapper_style, body)
+
         meta = body.metadata or {}
         content = '<?xml version="1.0" encoding="UTF-8"?>'
         content += '<!DOCTYPE en-note SYSTEM "http://xml.evernote.com/pub/enml2.dtd">'
@@ -446,8 +454,8 @@ class EvernoteDo():
                      b64encode(contents.encode('utf8')).decode('utf8'),
                      SUBLIME_EVERNOTE_COMMENT_END))
         content += hidden
-        content += body
-        LOG(body)
+        content += body_with_wrapper
+        LOG(body_with_wrapper)
         content += '</en-note>'
         note.title = meta.get("title", note.title)
         tags = meta.get("tags", note.tagNames)


### PR DESCRIPTION
I'm seeking a way to add a global wrapper to users' notes. By this way, it is possible to set font, color, etc for the entire note.