### PR TITLE
Add command to sync current note with the version from Evernote

### DIFF
--- a/Default.sublime-commands
+++ b/Default.sublime-commands
@@ -29,5 +29,6 @@
     { "command": "save_evernote_note", "caption": "Evernote: Update Evernote Note" },
     { "command": "new_evernote_note", "caption": "Evernote: New empty note" },
     { "command": "evernote_insert_attachment", "caption": "Evernote: Insert Attachment Here" },
-    { "command": "evernote_show_attachments", "caption": "Evernote: Show Attachments" }
+    { "command": "evernote_show_attachments", "caption": "Evernote: Show Attachments" },
+    { "command": "sync_from_evernote", "caption": "Evernote: Sync from Evernote" }
 ]

--- a/Default.sublime-commands
+++ b/Default.sublime-commands
@@ -30,5 +30,5 @@
     { "command": "new_evernote_note", "caption": "Evernote: New empty note" },
     { "command": "evernote_insert_attachment", "caption": "Evernote: Insert Attachment Here" },
     { "command": "evernote_show_attachments", "caption": "Evernote: Show Attachments" },
-    { "command": "sync_from_evernote", "caption": "Evernote: Sync from Evernote" }
+    { "command": "revert_to_evernote", "caption": "Evernote: Revert to version on Evernote" }
 ]

--- a/sublime_evernote.py
+++ b/sublime_evernote.py
@@ -618,6 +618,7 @@ class SendToEvernoteCommand(EvernoteDoText):
                     view.settings().set("$evernote", True)
                     view.settings().set("$evernote_guid", cnote.guid)
                     view.settings().set("$evernote_title", cnote.title)
+                    view.settings().set("$evernote_modified", view.change_count())
                     view.set_syntax_file(self.md_syntax)
                 self.message("Successfully posted note: guid:%s" % cnote.guid, 10000)
                 self.update_status_info(cnote)

--- a/sublime_evernote.py
+++ b/sublime_evernote.py
@@ -989,12 +989,12 @@ class ViewInEvernoteClientCommand(EvernoteDoText):
         return bool(self.view.settings().get("$evernote_guid", False))
 
 
-class SyncFromEvernoteCommand(OpenEvernoteNoteCommand):
+class RevertToEvernoteCommand(OpenEvernoteNoteCommand):
 
     def do_run(self, **kwargs):
         open_new_file = False
         if self.view.change_count() > self.view.settings().get("$evernote_modified"):
-            answer = sublime.yes_no_cancel_dialog("Note has been modified and syncing from Evernote will replace it's contents. Do you want to replace?", "Replace", "Open in new tab")
+            answer = sublime.yes_no_cancel_dialog("Note has been modified and reverting to version from Evernote will replace it's contents. Do you want to replace?", "Replace", "Open in new tab")
             if answer == sublime.DIALOG_NO:
                 open_new_file = True
             elif answer == sublime.DIALOG_CANCEL:
@@ -1002,7 +1002,7 @@ class SyncFromEvernoteCommand(OpenEvernoteNoteCommand):
 
         note_guid = self.view.settings().get("$evernote_guid")
         self.open_note(note_guid, open_new_file=open_new_file, **kwargs)
-        self.message("Syncing note, please wait...")
+        self.message("Loading note, please wait...")
 
     def is_enabled(self):
         if self.window.active_view().settings().get("$evernote_guid", False):

--- a/sublime_evernote.py
+++ b/sublime_evernote.py
@@ -78,19 +78,17 @@ def metadata_header(title="", tags=[], notebook="", **kw):
     return METADATA_HEADER % (title, json.dumps(tags, ensure_ascii=False), notebook)
 
 
-def append_to_view(view, text):
-    view.run_command('append', {
-        'characters': text,
-    })
-    return view
-
-
 def insert_to_view(view, text):
     view.run_command('insert', {
         'characters': text,
     })
     return view
 
+def replace_view_text(view, text):
+    view.run_command('replace_view_text', {
+        'characters': text
+    })
+    return view
 
 def find_syntax(lang, default=None):
     res = sublime.find_resources("%s.*Language" % lang)
@@ -798,7 +796,11 @@ class OpenEvernoteNoteCommand(EvernoteDoWindow):
                     except Exception as e:
                         mdtxt = note.content
                         LOG("Conversion failed", e)
-                newview = self.window.new_file()
+
+                if unk_args.get('open_new_file', True) == False:
+                    newview = self.window.active_view()
+                else:
+                    newview = self.window.new_file()
                 newview.settings().set("$evernote", True)
                 newview.settings().set("$evernote_guid", note.guid)
                 newview.settings().set("$evernote_title", note.title)
@@ -810,7 +812,7 @@ class OpenEvernoteNoteCommand(EvernoteDoWindow):
                 note_contents = note.content
             newview.set_syntax_file(syntax)
             newview.set_scratch(True)
-            append_to_view(newview, note_contents)
+            replace_view_text(newview, note_contents)
             newview.show(0)
             self.message('Note "%s" opened!' % note.title)
             self.update_status_info(note, newview)
@@ -985,6 +987,26 @@ class ViewInEvernoteClientCommand(EvernoteDoText):
     def is_enabled(self):
         return bool(self.view.settings().get("$evernote_guid", False))
 
+
+class SyncFromEvernoteCommand(OpenEvernoteNoteCommand):
+
+    def do_run(self, **kwargs):
+        open_new_file = False
+        if self.view.change_count() > self.view.settings().get("$evernote_modified"):
+            answer = sublime.yes_no_cancel_dialog("Note has been modified and syncing from Evernote will replace it's contents. Do you want to replace?", "Replace", "Open in new tab")
+            if answer == sublime.DIALOG_NO:
+                open_new_file = True
+            elif answer == sublime.DIALOG_CANCEL:
+                return
+
+        note_guid = self.view.settings().get("$evernote_guid")
+        self.open_note(note_guid, open_new_file=open_new_file, **kwargs)
+        self.message("Syncing note, please wait...")
+
+    def is_enabled(self):
+        if self.window.active_view().settings().get("$evernote_guid", False):
+            return True
+        return False
 
 class EvernoteInsertAttachment(EvernoteDoText):
 
@@ -1170,6 +1192,12 @@ class ClearEvernoteCacheCommand(sublime_plugin.WindowCommand):
     def run(self):
         EvernoteDo.clear_cache()
         LOG("Cache cleared!")
+
+
+class ReplaceViewTextCommand(sublime_plugin.TextCommand):
+    def run(self, edit, characters):
+        self.view.erase(edit, sublime.Region(0, self.view.size()))
+        self.view.insert(edit, 0, characters)
 
 
 class EvernoteListener(EvernoteDo, sublime_plugin.EventListener):


### PR DESCRIPTION
The use case that this pull request is implementing is:
* I use sublime with sublime-evernote on 2 computers
* I keep a tab with a note on both of them and when I switch between them I have to update the note to the state that is in the Evernote
* Right now the only way to do it is using search/recent notes, but I have to know what is the title, etc. However I have the note already opened, so why just not sync this note from Evernote
* This change does exactly this - you can sync current note from Evernote
    * It will warn you if you edited the note already

For me it saves a lot of time, so I thought I will share it :)

Let me know if you have any questions/comments.