### PR TITLE
Make sure that logged messages does not contain multibyte UTF charact…

### DIFF
--- a/sublime_evernote.py
+++ b/sublime_evernote.py
@@ -53,7 +53,7 @@ DEBUG = False
 
 def LOG(*args):
     if DEBUG:
-        print("Evernote:", *args)
+        print("Evernote:", str(*args).encode('ascii', 'replace').decode())
 
 
 def extractTags(tags):


### PR DESCRIPTION
I described the problem in this issue: https://github.com/bordaigorl/sublime-evernote/issues/91

It only happens when debug setting is "True" and note has multibyte UTF characters (e.g. polish characters). Because of this I'm not able to turn on debug mode, as most of my notes have polish characters in it.
The best solution would be for sublime to fix `sublime_api.log_message()` function (see sublime.py#9).
