### PR TITLE
add 'backup_source_file' feature

### DIFF
--- a/Evernote.sublime-settings
+++ b/Evernote.sublime-settings
@@ -30,5 +30,6 @@
     "sort_notebooks": false,
     "show_stacks": true,
     "open_single_result": true,
-    "warn_on_close": true
+    "warn_on_close": true,
+    "backup_source_file": false
 }

--- a/README.md
+++ b/README.md
@@ -252,6 +252,7 @@ Setting                   | Purpose
 `gfm_tables`              | enable GFM table syntax (default `true`)
 `wiki_tables`             | enable Wiki table syntax (default `false`)
 `debug`                   | enables logging in the console
+`backup_source_file`        | enables source text backup
 
 
 # Acknowledgements


### PR DESCRIPTION
I created the #96 issue. I implements it for my convenience.
How do yout thiank about it?

 - - - - - -

Add 'backup_source_file' feature.
 - When 'send_to_evernote' is called, it adds a source mardkwon as an
   attachment 'sublime-evernote.0.txt' file.
 - When 'save_evernote_note' is called, it increments the revision
   number and adds a source markdown as 'sublime-evernote.{N}.txt'.

User can control this feature by setting 'backup_source_file' option.

Current sublime-evernote saves only converted result. When I access
the note though web and  other interface, It's hard go get original markdown.
So I add a source text backup feature. It adds mardown files with
revision like 'sublime-evernote.0.txt', 'sublime-evernote.1.txt', ...