### PR TITLE
Adding `open_evernote_note_by_guid` command

### DIFF
--- a/Default.sublime-commands
+++ b/Default.sublime-commands
@@ -6,6 +6,7 @@
     { "command": "view_in_evernote_client", "caption": "Evernote: View Note in Evernote client" },
     { "command": "open_evernote_note", "args": {"by_searching": true}, "caption": "Evernote: Search Note" },
     { "command": "open_evernote_note", "args": {"max_notes": 10, "by_searching": "*", "order": "updated", "ascending": false}, "caption": "Evernote: List recent notes" },
+    { "command": "open_evernote_note_by_guid", "caption": "Evernote: Open Note by GUID from clipboard" },
     { "command": "attach_to_evernote_note", "caption": "Evernote: Attach current file to a note" },
     { "command": "insert_link_to_evernote_note", "caption": "Evernote: Insert link to a note (browse)" },
     { "command": "insert_link_to_evernote_note", "args": {"by_searching": true}, "caption": "Evernote: Insert link to a note (search)" },

--- a/sublime_evernote.py
+++ b/sublime_evernote.py
@@ -907,6 +907,13 @@ class OpenEvernoteNoteCommand(EvernoteDoWindow):
             sublime.error_message(explain_error(e))
 
 
+class OpenEvernoteNoteByGuid(EvernoteDoWindow):
+
+    def do_run(self, **kwargs):
+        guid = sublime.get_clipboard()
+        self.view.window().run_command('open_evernote_note', {'note_guid': guid})
+
+
 class AttachToEvernoteNote(OpenEvernoteNoteCommand):
 
     def open_note(self, guid, insert_in_content=True, filename=None, prompt=False, **unk_args):


### PR DESCRIPTION
Retrieve the Evernote GUID from the clipboard and open the corresponding note.
This command will help to pass a note from Evernote Application to Sublime Text using Applescript and subl command line (see Applescript Gist [here](https://gist.github.com/thorstenhuhn/0a0fe08542a14aec8565))