### PR TITLE
I found a bug from"evernote: insert attachment here" in windows

### DIFF
--- a/sublime_evernote.py
+++ b/sublime_evernote.py
@@ -1111,17 +1111,17 @@ class EvernoteInsertAttachment(EvernoteDoText):
             attr = {}
             mimet = None
             try:
-                if urllib.parse.urlparse(filename).scheme != ""  and urllib.parse.urlparse(filename).scheme not in [chr(i) for i in range(97,123)]:
+                if os.path.isfile(filename):
+					datafile = os.path.expanduser(filename)
+                    with open(datafile, 'rb') as content_file:
+                        filecontents = content_file.read()
+                    attr = {"fileName": os.path.basename(datafile)}
+                else:
                     # download
                     response = urllib.request.urlopen(filename)
                     filecontents = response.read()
                     attr = {"sourceURL": filename}
                     mimet = response.info().get_content_type()
-                else:
-                    datafile = os.path.expanduser(filename)
-                    with open(datafile, 'rb') as content_file:
-                        filecontents = content_file.read()
-                    attr = {"fileName": os.path.basename(datafile)}
             except Exception as e:
                 sublime.error_message(
                     "Evernote plugin has troubles locating the specified file/URL.\n" +

--- a/sublime_evernote.py
+++ b/sublime_evernote.py
@@ -1111,17 +1111,17 @@ class EvernoteInsertAttachment(EvernoteDoText):
             attr = {}
             mimet = None
             try:
-                if os.path.isfile(filename):
-					datafile = os.path.expanduser(filename)
-                    with open(datafile, 'rb') as content_file:
-                        filecontents = content_file.read()
-                    attr = {"fileName": os.path.basename(datafile)}
-                else:
+                if urllib.parse.urlparse(filename).scheme != ""  and urllib.parse.urlparse(filename).scheme not in [chr(i) for i in range(97,123)]:
                     # download
                     response = urllib.request.urlopen(filename)
                     filecontents = response.read()
                     attr = {"sourceURL": filename}
                     mimet = response.info().get_content_type()
+                else:
+                    datafile = os.path.expanduser(filename)
+                    with open(datafile, 'rb') as content_file:
+                        filecontents = content_file.read()
+                    attr = {"fileName": os.path.basename(datafile)}
             except Exception as e:
                 sublime.error_message(
                     "Evernote plugin has troubles locating the specified file/URL.\n" +

--- a/sublime_evernote.py
+++ b/sublime_evernote.py
@@ -1111,7 +1111,7 @@ class EvernoteInsertAttachment(EvernoteDoText):
             attr = {}
             mimet = None
             try:
-                if urllib.parse.urlparse(filename).scheme != "":
+                if urllib.parse.urlparse(filename).scheme != ""  and urllib.parse.urlparse(filename).scheme not in [chr(i) for i in range(97,123)]:
                     # download
                     response = urllib.request.urlopen(filename)
                     filecontents = response.read()

--- a/sublime_evernote.py
+++ b/sublime_evernote.py
@@ -1111,7 +1111,7 @@ class EvernoteInsertAttachment(EvernoteDoText):
             attr = {}
             mimet = None
             try:
-                if urllib.parse.urlparse(filename).scheme != ""  and urllib.parse.urlparse(filename).scheme not in [chr(i) for i in range(97,123)]:
+                if urllib.parse.urlparse(filename).scheme != "":
                     # download
                     response = urllib.request.urlopen(filename)
                     filecontents = response.read()

--- a/sublime_evernote.py
+++ b/sublime_evernote.py
@@ -1111,17 +1111,17 @@ class EvernoteInsertAttachment(EvernoteDoText):
             attr = {}
             mimet = None
             try:
-                if urllib.parse.urlparse(filename).scheme != "":
+                if os.path.isfile(filename):
+                    datafile = os.path.expanduser(filename)
+                    with open(datafile, 'rb') as content_file:
+                        filecontents = content_file.read()
+                    attr = {"fileName": os.path.basename(datafile)}
+                else:
                     # download
                     response = urllib.request.urlopen(filename)
                     filecontents = response.read()
                     attr = {"sourceURL": filename}
                     mimet = response.info().get_content_type()
-                else:
-                    datafile = os.path.expanduser(filename)
-                    with open(datafile, 'rb') as content_file:
-                        filecontents = content_file.read()
-                    attr = {"fileName": os.path.basename(datafile)}
             except Exception as e:
                 sublime.error_message(
                     "Evernote plugin has troubles locating the specified file/URL.\n" +


### PR DESCRIPTION
when I press the command evernote: insert attachment here,i was asked to
type a filename("C:/123.jpg") .But i got an error message
:

error: Evernote plugin has troubles locating the specified file/URL.
Evernote plugin error, please see the console for more details.
Then contact developer at
https://github.com/bordaigorl/sublime-evernote/issues
Evernote plugin error: <urlopen error unknown url type: g>

After I search the google, i found there are something wrongs in the
source code(line 1114):

https://github.com/bordaigorl/sublime-evernote/blob/master/sublime_evernote.py#L1113

Related code:
```python
if urllib.parse.urlparse(filename).scheme != "":
# download
response = urllib.request.urlopen(filename)
filecontents = response.read()
attr = {"sourceURL": filename}
mimet = response.info().get_content_type()
else:
datafile = os.path.expanduser(filename)
with open(datafile, 'rb') as content_file:
filecontents = content_file.read()
attr = {"fileName": os.path.basename(datafile)}
```
where `urllib.parse.urlparse(filename).scheme` in windows, filename will
be "C:/123.jpg"
and this statement will return a "C"  ,so the filename  "C:/123.jpg"
will be considered as an url according to this code.

so one of  the solution for this bug in windows is that:
```python
if urllib.parse.urlparse(filename).scheme != ""  and
urllib.parse.urlparse(filename).scheme not in [chr(i) for i in
range(97,123)] :
# download
response = urllib.request.urlopen(filename)
filecontents = response.read()
attr = {"sourceURL": filename}
mimet = response.info().get_content_type()
else:
datafile = os.path.expanduser(filename)
with open(datafile, 'rb') as content_file:
filecontents = content_file.read()
attr = {"fileName": os.path.basename(datafile)}
```
use this statement instead
```python
urllib.parse.urlparse(filename).scheme != ""  and
urllib.parse.urlparse(filename).scheme not in [chr(i) for i in
range(97,123)]
```
which means that to find out if the 'C' is a letter, so as to separate
the area HTTPS FTP HTTP and orther urls

e.g.
```python
>>> filename='http://www.google.com/123.jpg'
>>> urllib.parse.urlparse(filename).scheme != ""  and
urllib.parse.urlparse(filename).scheme not in [chr(i) for i in
range(97,123)]
True
>>> filename="/123/123.jpg"
>>> urllib.parse.urlparse(filename).scheme != ""  and
urllib.parse.urlparse(filename).scheme not in [chr(i) for i in
range(97,123)]
False
>>> filename='c:/123.jpg'
>>> urllib.parse.urlparse(filename).scheme != ""  and
urllib.parse.urlparse(filename).scheme not in [chr(i) for i in
range(97,123)]
False
```