### PR TITLE
New codeblocks

### DIFF
--- a/lib/html2text.py
+++ b/lib/html2text.py
@@ -449,18 +449,34 @@ class HTML2Text(HTMLParser.HTMLParser):
                 if start and google_has_height(tag_style):
                     self.p()
                 else:
-                    self.soft_br()
+                    self.br()
             else:
                 if start == 1:
-                    if attrs and attrs.get("title") != "footnotes":
+                    if attrs and '-en-codeblock:true' in attrs.get("style"):
+                        self.o("```")
+                        self.block_stack.append("encodeblock")
+                        self.pre = "encodeblock"
+                        self.startpre = 1
+                    elif self.pre == "encodeblock":
+                        self.block_stack.append(False)
+                    elif attrs and attrs.get("title") != "footnotes":
                         self.block_stack.append(True)
                         self.o(tag_str(tag+' markdown="1"', attrs, start))
+                        self.p()
                     else:
                         self.block_stack.append(False)
+                        self.p()
                 elif start == 0:
-                    if self.block_stack.pop():
+                    t = self.block_stack.pop()
+                    if t == "encodeblock":
+                        self.pre = 0
+                        self.o("```")
+                    elif t == True:
                         self.o('</%s>' % tag)
-                self.p()
+                    elif self.pre:
+                        self.pbr()
+                    else:
+                        self.p()
 
         if tag == 'p':
             if self.google_doc:

--- a/lib/html2text.py
+++ b/lib/html2text.py
@@ -452,7 +452,10 @@ class HTML2Text(HTMLParser.HTMLParser):
                     self.br()
             else:
                 if start == 1:
-                    if attrs and '-en-codeblock:true' in attrs.get("style"):
+                    if attrs and '-en-paragraph:true' in attrs.get("style"):
+                        self.block_stack.append(False)
+                        self.p()
+                    elif attrs and '-en-codeblock:true' in attrs.get("style"):
                         self.o("```")
                         self.block_stack.append("encodeblock")
                         self.pre = "encodeblock"

--- a/lib/html2text.py
+++ b/lib/html2text.py
@@ -444,6 +444,11 @@ class HTML2Text(HTMLParser.HTMLParser):
                 self.inheader = False
                 return # prevent redundant emphasis marks on headers
 
+        if attrs and "-evernote-webclip" in attrs.get("style", "") and start:
+            self.out('\n\n'+tag_str(tag, attrs, start))
+            self.verbatim = [tag, 1]
+            return
+
         if tag == 'div':
             if self.google_doc:
                 if start and google_has_height(tag_style):
@@ -460,7 +465,7 @@ class HTML2Text(HTMLParser.HTMLParser):
                         self.block_stack.append("encodeblock")
                         self.pre = "encodeblock"
                         self.startpre = 1
-                    elif self.pre == "encodeblock":
+                    elif self.pre:
                         self.block_stack.append(False)
                     elif attrs and attrs.get("title") != "footnotes":
                         self.block_stack.append(True)
@@ -757,7 +762,9 @@ class HTML2Text(HTMLParser.HTMLParser):
             bq = (">" * self.blockquote)
             if not (force and data and data[0] == ">") and self.blockquote: bq += " "
 
-            if self.pre == "indent":
+            if self.verbatim:
+                data = data.replace("\n", "\n ")
+            elif self.pre == "indent":
                 if not self.list:
                     bq += "    "
                 #else: list content is already partially indented

--- a/sublime_evernote.py
+++ b/sublime_evernote.py
@@ -338,6 +338,7 @@ class EvernoteDo():
                 css[tag] = css[tag].strip()
                 if len(css[tag]) > 0 and not css[tag].endswith(";"):
                     css[tag] = css[tag] + ";"
+            css['pre'] = css.get('pre', "") + "-en-codeblock:true;"
             EvernoteDo.MD_EXTRAS['inline-css'] = css
         self.md_syntax = self.settings.get("md_syntax")
         if not self.md_syntax:


### PR DESCRIPTION
Attempt to add support for undocumented `-en-paragraph`, `-en-webclip` and `-en-codeblock` styles.
This tries to address issues #184, #190,  #207.
This needs testing and may break in the future (because the features it's trying to support are undocumented and subject to changes).
Any report of testing most welcome.